### PR TITLE
✨ (deadlink_checker.yml): add GitHub workflow for checking Markdown l…

### DIFF
--- a/.github/workflows/deadlink_checker.yml
+++ b/.github/workflows/deadlink_checker.yml
@@ -1,0 +1,19 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+    - master
+  schedule:
+  # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+  - cron: "0 9 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'


### PR DESCRIPTION
…inks in the repository on push to master branch and scheduled daily at 9:00 AM using cron job. The workflow runs on ubuntu-latest and utilizes the github-action-markdown-link-check action with quiet and verbose modes enabled.